### PR TITLE
ハンドラを拡張子で判定する

### DIFF
--- a/packages/s2s-cli/src/__snapshots__/index.test.js.snap
+++ b/packages/s2s-cli/src/__snapshots__/index.test.js.snap
@@ -7,3 +7,25 @@ exports[`throw errors opts.plugins !== Array 1`] = `"Expected a Array, got strin
 exports[`throw errors opts.templates !== Array 1`] = `"Expected a Array got string"`;
 
 exports[`throw errors opts.watch == null 1`] = `"required watch"`;
+
+exports[`ファイルが追加されたときhandlePluginsが呼ばれる 1`] = `
+Object {
+  "afterHooks": Array [
+    [Function],
+  ],
+  "plugins": Array [
+    Object {
+      "plugin": "dummy",
+      "test": /dummy/,
+    },
+  ],
+  "prettier": true,
+  "templates": Array [
+    Object {
+      "input": "dummy",
+      "test": /dummy/,
+    },
+  ],
+  "watch": "app",
+}
+`;

--- a/packages/s2s-cli/src/cli/loadConfig.js
+++ b/packages/s2s-cli/src/cli/loadConfig.js
@@ -1,10 +1,10 @@
 // @flow
 import findUp from 'find-up'
-import type { Opts } from 'types'
+import type { Config } from 'types'
 
 const S2S_CONFIG_JS = 's2s.config.js'
 
-export default function loadConfig(cwd: string = process.cwd()): Opts {
+export default function loadConfig(cwd: string = process.cwd()): Config {
   const fp = findUp.sync(S2S_CONFIG_JS, { cwd })
   if (!fp) {
     throw new Error(`required ${S2S_CONFIG_JS}`)

--- a/packages/s2s-cli/src/index.js
+++ b/packages/s2s-cli/src/index.js
@@ -3,7 +3,7 @@ import 'babel-polyfill' // eslint-disable-line
 import chalk from 'chalk'
 import chokidar from 'chokidar'
 import prettierHook from 's2s-hook-prettier'
-import type { Opts, Path } from 'types'
+import type { Config, Path } from 'types'
 import handlePlugins from './handlers/plugins'
 import handleTemplates from './handlers/templates'
 
@@ -23,7 +23,7 @@ export default ({
   afterHooks = [],
   templatesDir,
   prettier: isPrettier = true,
-}: Opts) => {
+}: Config) => {
   if (!watch) {
     throw new Error('required watch')
   }

--- a/packages/s2s-cli/src/index.js
+++ b/packages/s2s-cli/src/index.js
@@ -16,14 +16,19 @@ function createWatcher(rootPath: Path) {
   return watcher
 }
 
-export default ({
-  watch,
-  plugins = [],
-  templates = [],
-  afterHooks = [],
-  templatesDir,
-  prettier: isPrettier = true,
-}: Config) => {
+export default (inputConfg: Config) => {
+  const config = {
+    ...{
+      plugins: [],
+      templates: [],
+      afterHooks: [],
+      prettier: true,
+    },
+    ...inputConfg,
+  }
+
+  const { watch, plugins, templates, afterHooks } = config
+
   if (!watch) {
     throw new Error('required watch')
   }
@@ -39,24 +44,23 @@ export default ({
   if (!Array.isArray(afterHooks)) {
     throw new TypeError(`Expected a Array got ${typeof afterHooks}`)
   }
-
   const watcher = createWatcher(watch)
 
-  if (isPrettier) {
+  if (config.prettier) {
     afterHooks.push(prettierHook())
   }
 
   if (plugins.length > 0) {
     for (const type of ['add', 'change', 'unlink']) {
       watcher.on(type, (input: Path) => {
-        handlePlugins(input, type, plugins, afterHooks)
+        handlePlugins(input, type, config)
       })
     }
   }
 
   if (templates.length > 0) {
     watcher.on('add', (input: Path) => {
-      handleTemplates(input, templates, templatesDir)
+      handleTemplates(input, templates, config.templatesDir)
     })
   }
 

--- a/packages/s2s-cli/src/index.test.js
+++ b/packages/s2s-cli/src/index.test.js
@@ -74,7 +74,7 @@ test('ファイルが追加されたときhandlePluginsが呼ばれる', () => {
   const result = handlePluginsSpy.mock.calls[0]
   expect(result[0]).toBe('hello')
   expect(result[1]).toBe('add')
-  expect(result[2]).toEqual([{ plugin: 'dummy', test: /dummy/ }])
+  expect(result[2]).toMatchSnapshot()
 })
 
 test('pluginsがない場合、ファイルが追加されたときhandlePluginsは呼ばれない', () => {
@@ -97,9 +97,9 @@ test('templatesがない場合、ファイルが追加されたときhandleTempl
   expect(handleTemplateSpy).not.toBeCalled()
 })
 
-test('when prettier = false', () => {
+test('prettier = falseのとき、 afterHooksが空配列でhandlePluginが呼ばれる', () => {
   watcher = m(setup({ prettier: false }))
   watcher.emit('add', 'hello')
   const result = handlePluginsSpy.mock.calls[0]
-  expect(result[3]).toEqual([])
+  expect(result[2].afterHooks).toEqual([])
 })

--- a/packages/s2s-cli/src/index.test.js
+++ b/packages/s2s-cli/src/index.test.js
@@ -1,6 +1,6 @@
 // @flow
 import cases from 'jest-in-case'
-import type { Opts } from 'types'
+import type { Config } from 'types'
 import * as plugins from './handlers/plugins'
 import * as templates from './handlers/templates'
 import m from '.'
@@ -10,7 +10,7 @@ let handlePluginsSpy
 let handleTemplateSpy
 let watcher
 
-function setup(opts: $Shape<Opts>) {
+function setup(opts: $Shape<Config>) {
   return {
     watch: 'app',
     plugins: [{ test: /dummy/, plugin: 'dummy' }],

--- a/types/index.js
+++ b/types/index.js
@@ -31,7 +31,7 @@ export type Template = {|
 
 export type AfterHook = (code: Code, path: Path) => Code
 
-export type Opts = {|
+export type Config = {|
   watch: Path, // file, dir, glob, or array
   plugins?: Plugin[], // eslint-disable-line
   templatesDir?: string,

--- a/types/index.js
+++ b/types/index.js
@@ -31,13 +31,14 @@ export type Template = {|
 
 export type AfterHook = (code: Code, path: Path) => Code
 
-export type Config = {|
+export type Config = {
   watch: Path, // file, dir, glob, or array
   plugins?: Plugin[], // eslint-disable-line
   templatesDir?: string,
   templates?: Template[], // eslint-disable-line
-  afterHooks: AfterHook[], // eslint-disable-line
+  afterHooks?: AfterHook[], // eslint-disable-line
   prettier: boolean,
-|}
+  handlerMapper?: { [extensions: string]: Handler },
+}
 
 export type HandlerType = 'S2S' | 'TEMPLATE'


### PR DESCRIPTION
<!--
English/日本語

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!


全て日本語で入力して構いません。むしろ、あなたが日本語に精通していればそちらの方が素早い対応ができます。(ええ、私は日本人です)

プロジェクトに興味を持ってくれてありがとうございます。提出されたバグとPRに感謝します！
このプロジェクトの行動規範(CODE_OF_CONDUCT)を確認し、それに従ってください。（CODE_OF_CONDUCT.mdファイルにあります）

また、あなたがコントリビューションガイドラインを読んでそれに従ってください。（CONTRIBUTING.mdファイルにあります）

もし、これがはじめてのオープンソースへの貢献なら、素晴らしい無料の短いビデオチュートリアルが助けになるはずです。 http://kcd.im/pull-request

レビューを迅速にするために、以下の情報を記入してください。あなたのプルリクエストのマージを期待しています！
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されてしますか？ (機能/バグはここで修正されていますか？) -->
**What**:  ハンドラを拡張子で判定するオプションの追加

s2s.config.jsで以下のような記述が可能
```js
handlerMapper: {
  '*.(js|jsx)': handlerBabel,
  '*.(ts|tsx)': hanlderTypeScript,
}
```

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: それぞれのプラグインごとにハンドラを指定するのが面倒なため、拡張子で判断するための設定が必要だった。


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: jestの設定を真似た


<!-- Have you done all of these things? / これらすべてのことを終えましたか？-->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes / もしあなたの変更に関係がなければそれぞれの行の末尾に"N/A"と追加してください。-->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" / アイテムをチェックするためには、このように"x"と入力します。 "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A<!-- this is optional, see the contributing guidelines for instructions -->

<!--
- [ ] ドキュメント
- [ ] テスト
- [ ] マージされる準備 (あなたの意見では、レビューされたらすぐにマージする準備が整っていますか？)
- [ ] コントリビューションテーブルへ自分を追加 (これはオプションです。コントリビューションガイドを確定してください)
(これは翻訳です。こちらではなく、英語の方にチェックを入れてください)
-->


<!-- feel free to add additional comments. コメントを自由に追加してください-->
