### PR TITLE
feat(watcher-ignored): createWatcher with ignored parameter.

### DIFF
--- a/packages/s2s-cli/src/__snapshots__/index.test.js.snap
+++ b/packages/s2s-cli/src/__snapshots__/index.test.js.snap
@@ -13,6 +13,10 @@ Object {
   "afterHooks": Array [
     [Function],
   ],
+  "ignored": Array [
+    ".git/",
+    "node_modules/",
+  ],
   "plugins": Array [
     Object {
       "plugin": "dummy",

--- a/packages/s2s-cli/src/index.js
+++ b/packages/s2s-cli/src/index.js
@@ -3,14 +3,15 @@ import 'babel-polyfill' // eslint-disable-line
 import chalk from 'chalk'
 import chokidar from 'chokidar'
 import prettierHook from 's2s-hook-prettier'
-import type { Config, Path } from 'types'
+import type { Config, Path, AnymatchPath } from 'types'
 import handlePlugins from './handlers'
 import handleTemplates from './templates'
 
-function createWatcher(rootPath: Path) {
+function createWatcher(rootPath: Path, ignored: AnymatchPath) {
   const watcher = chokidar.watch(rootPath, {
     cwd: process.cwd(),
     ignoreInitial: true,
+    ignored,
   })
 
   return watcher
@@ -23,11 +24,12 @@ export default (inputConfg: Config) => {
       templates: [],
       afterHooks: [],
       prettier: true,
+      ignored: ['.git/', 'node_modules/'],
     },
     ...inputConfg,
   }
 
-  const { watch, plugins, templates, afterHooks } = config
+  const { watch, plugins, templates, afterHooks, ignored } = config
 
   if (!watch) {
     throw new Error('required watch')
@@ -44,7 +46,7 @@ export default (inputConfg: Config) => {
   if (!Array.isArray(afterHooks)) {
     throw new TypeError(`Expected a Array got ${typeof afterHooks}`)
   }
-  const watcher = createWatcher(watch)
+  const watcher = createWatcher(watch, ignored)
 
   if (config.prettier) {
     afterHooks.push(prettierHook())

--- a/packages/s2s-cli/src/index.test.js
+++ b/packages/s2s-cli/src/index.test.js
@@ -10,7 +10,7 @@ let handlePluginsSpy
 let handleTemplateSpy
 let watcher
 
-function setup(opts: $Shape<Config>) {
+function setup(opts: $Shape<Config>): Config {
   return {
     watch: 'app',
     plugins: [{ test: /dummy/, plugin: 'dummy' }],
@@ -102,4 +102,9 @@ test('prettier = falseのとき、 afterHooksが空配列でhandlePluginが呼�
   watcher.emit('add', 'hello')
   const result = handlePluginsSpy.mock.calls[0]
   expect(result[2].afterHooks).toEqual([])
+})
+
+test('ignoredに指定されたパターンに該当するファイルは、呼ばれない', () => {
+  watcher = m(setup({ ignored: ['hoge'] }))
+  expect(watcher.options.ignored).toEqual(['hoge'])
 })

--- a/types/index.js
+++ b/types/index.js
@@ -5,6 +5,8 @@ export type Code = string
 export type EventType = 'add' | 'change' | 'unlink'
 export type Only = EventType[]
 
+export type AnymatchPath = RegExp | string | (RegExp | string)[]
+
 export type HandlerOpts = {
   eventPath: Path,
   filename: Path,
@@ -39,6 +41,10 @@ export type Template = {|
 
 export type AfterHook = (code: Code, path: Path) => Code
 
+/**
+ * @see https://github.com/paulmillr/chokidar
+ * @see https://github.com/es128/anymatch
+ */
 export type Config = {
   watch: Path, // file, dir, glob, or array
   plugins?: Plugin[], // eslint-disable-line
@@ -47,6 +53,7 @@ export type Config = {
   afterHooks?: AfterHook[], // eslint-disable-line
   prettier: boolean,
   handlerMapper?: { [extensions: string]: Handler },
+  ignored?: AnymatchPath, // file, dir, glob, regexp, or array
 }
 
 export type HandlerType = 'S2S' | 'TEMPLATE'


### PR DESCRIPTION
**What**:
issue #86 対応

**Why**:
ignore指定できると、.gitとかnode_modules/とかdist/とかその手のところに対して一括で無視できて便利かなーと思いました。

**How**:

* types/index.js に AnymatchPath型とConfigへのignored?: Anymatch の登録
* index.js 修正
* snapshot 修正

**Checklist**:

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

テストなんですが、実ファイルシステムを叩くようなテストなら可能なので、一応 index.test.js にコメントアウトした状態のテストは追加してますが、これをどうしましょうか？というところです。

beforeEachでtmp作ってそこに書いて、afterEachでtmp消すか…