### PR TITLE
feat(breakingChanges): chnage Hanler type breaking changes

### DIFF
--- a/packages/s2s-cli/src/handlers/__snapshots__/index.test.js.snap
+++ b/packages/s2s-cli/src/handlers/__snapshots__/index.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Codeを返す旧ハンドラーの場合はS2Sと表示させる 1`] = `"S2S packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;
+
 exports[`handlePlugin pluginNameが与えられたとき、それを表示する 1`] = `"babel:syntax-flow packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;
 
 exports[`handlePlugin when eventPath match 1`] = `"babel packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;

--- a/packages/s2s-cli/src/handlers/__snapshots__/index.test.js.snap
+++ b/packages/s2s-cli/src/handlers/__snapshots__/index.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`handlePlugin when eventPath match 1`] = `"S2S packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;
+exports[`handlePlugin pluginNameが与えられたとき、それを表示する 1`] = `"babel:syntax-flow packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;
+
+exports[`handlePlugin when eventPath match 1`] = `"babel packages/s2s-cli/src/handlers/__tests__/fixtures/a.js → packages/s2s-cli/src/handlers/__tests__/fixtures/a.js"`;
 
 exports[`handlePlugin with input option 1`] = `
 "// @flow

--- a/packages/s2s-cli/src/handlers/index.js
+++ b/packages/s2s-cli/src/handlers/index.js
@@ -32,7 +32,12 @@ export function handlePlugin(
   const filename = resolveInputPath(plugin.input, eventPath)
   const content = fs.readFileSync(filename, 'utf8')
 
-  const { code } = handler(content, { eventPath, plugin, filename })
+  const handlerResult = handler(content, { eventPath, plugin, filename })
+
+  const { code, meta } =
+    handlerResult && typeof handlerResult === 'string'
+      ? { code: handlerResult, meta: { handlerName: 'S2S' } }
+      : handlerResult
 
   if (!code && code === '') {
     return
@@ -48,7 +53,14 @@ export function handlePlugin(
     : eventPath
 
   writeFileSync(outputPath, result)
-  console.log(formatText('S2S', relativeFromCwd(eventPath), outputPath))
+
+  const { handlerName } = meta
+
+  const outputPrefix =
+    handlerName +
+    (meta.pluginName && meta.pluginName !== '' ? `:${meta.pluginName}` : '')
+
+  console.log(formatText(outputPrefix, relativeFromCwd(eventPath), outputPath))
 }
 
 function validate(plugin: Plugin, eventPath: Path, eventType: EventType) {

--- a/packages/s2s-cli/src/handlers/index.js
+++ b/packages/s2s-cli/src/handlers/index.js
@@ -32,7 +32,7 @@ export function handlePlugin(
   const filename = resolveInputPath(plugin.input, eventPath)
   const content = fs.readFileSync(filename, 'utf8')
 
-  const code = handler(content, { eventPath, plugin, filename })
+  const { code } = handler(content, { eventPath, plugin, filename })
 
   if (!code && code === '') {
     return

--- a/packages/s2s-cli/src/handlers/index.test.js
+++ b/packages/s2s-cli/src/handlers/index.test.js
@@ -58,6 +58,12 @@ test('handlePlugin when eventPath match', () => {
   expect(stripAnsi(logSpy.mock.calls[0][0])).toMatchSnapshot()
 })
 
+test('handlePlugin pluginNameが与えられたとき、それを表示する', () => {
+  const plugin = { test: /a.js/, plugin: 'syntax-flow' }
+  plugins.handlePlugin(...setup(plugin))
+  expect(stripAnsi(logSpy.mock.calls[0][0])).toMatchSnapshot()
+})
+
 test('handlePlugin with input option', () => {
   const plugin = { test: /a.js/, plugin: _plugin, input: getEventPath('a.js') }
   plugins.handlePlugin(...setup(plugin))

--- a/packages/s2s-cli/src/handlers/index.test.js
+++ b/packages/s2s-cli/src/handlers/index.test.js
@@ -64,6 +64,14 @@ test('handlePlugin pluginNameが与えられたとき、それを表示する', 
   expect(stripAnsi(logSpy.mock.calls[0][0])).toMatchSnapshot()
 })
 
+test('Codeを返す旧ハンドラーの場合はS2Sと表示させる', () => {
+  const plugin = { test: /a.js/, plugin: 'syntax-flow' }
+  const handler = x => x
+  // $FlowFixMe
+  plugins.handlePlugin(handler, setup(plugin)[1])
+  expect(stripAnsi(logSpy.mock.calls[0][0])).toMatchSnapshot()
+})
+
 test('handlePlugin with input option', () => {
   const plugin = { test: /a.js/, plugin: _plugin, input: getEventPath('a.js') }
   plugins.handlePlugin(...setup(plugin))

--- a/packages/s2s-cli/src/handlers/index.test.js
+++ b/packages/s2s-cli/src/handlers/index.test.js
@@ -164,6 +164,7 @@ test('use s2s-handler-typescript when extname of eventPath is .ts', () => {
   plugins.default(getEventPath('hello.ts'), 'add', {
     plugins: [plugin],
   })
+  // expect(writeSpy.mock.calls).toEqual({})
   expect(writeSpy.mock.calls[0][1]).toMatchSnapshot()
 })
 
@@ -183,30 +184,36 @@ test('handlePluginsのPlugin.testオプションはglobの配列を判定でき�
 
 describe('selectHandler', () => {
   test('ハンドラが渡された場合、そのハンドラを返す', () => {
-    const handler = x => x
+    const handler = x => ({ code: x, meta: { handlerName: 'x' } })
     expect(plugins.selectHandler({}, handler, 'a.ejs').name).toEqual('handler')
   })
 
   test('任意のハンドラーを渡すことができる', () => {
-    const testHandler = () => 'test'
+    const testHandler = () => ({
+      code: 'test',
+      meta: { handlerName: 'testHandler' },
+    })
     const receivedHandler = plugins.selectHandler(
       { '*.ejs': testHandler },
       undefined,
       'path/to/index.ejs'
     )
     // $FlowFixMe
-    expect(receivedHandler('', {})).toBe('test')
+    expect(receivedHandler('', {}).code).toBe('test')
   })
 
   test('デフォルトのハンドラより渡されたハンドラを優先する', () => {
-    const testHandler = () => 'test'
+    const testHandler = () => ({
+      code: 'test',
+      meta: { handlerName: 'testHandler' },
+    })
     const receivedHandler = plugins.selectHandler(
       { '*.js': testHandler },
       undefined,
       'path/to/index.js'
     )
     // $FlowFixMe
-    expect(receivedHandler('', {})).toBe('test')
+    expect(receivedHandler('', {}).code).toBe('test')
   })
 
   test('ハンドラがマッチしない場合、エラーを起こす', () => {

--- a/packages/s2s-cli/src/reporters/index.js
+++ b/packages/s2s-cli/src/reporters/index.js
@@ -12,11 +12,11 @@ export const trimAndFormatPath = (testPath: string) => {
 }
 
 export const formatText = (
-  handlerType: HandlerType,
+  handlerType: HandlerType | string,
   inputPath: string,
   outputPath: string
 ) => {
-  const color = handlerType === 'S2S' ? 'green' : 'cyan'
+  const color = handlerType === 'TEMPLATE' ? 'cyan' : 'green'
   const input = trimAndFormatPath(inputPath)
   const output = trimAndFormatPath(relativeFromCwd(outputPath))
   const header = chalk.reset.inverse.bold[color](handlerType)

--- a/packages/s2s-handler-babel-next/src/index.js
+++ b/packages/s2s-handler-babel-next/src/index.js
@@ -1,14 +1,11 @@
 // @flow
 import { transform } from '@babel/core'
-import type { Code, HandlerOpts } from 'types'
+import type { Handler } from 'types'
 
 // eslint-disable-next-line
 export type Opts = string | Function | [string | Function, Object]
 
-export default function babelNextHandler(
-  code: Code,
-  { eventPath, plugin, filename }: HandlerOpts
-): Code {
+export default ((code, { eventPath, plugin, filename }) => {
   if (!plugin || !plugin.plugin) {
     throw new Error('required plugin')
   }
@@ -26,5 +23,10 @@ export default function babelNextHandler(
     plugins: [lastPlugin],
   })
 
-  return result ? result.trim() : ''
-}
+  return {
+    code: result ? result.trim() : '',
+    meta: {
+      handlerName: 'babel/next',
+    },
+  }
+}: Handler)

--- a/packages/s2s-handler-babel-next/src/index.js
+++ b/packages/s2s-handler-babel-next/src/index.js
@@ -27,6 +27,7 @@ export default ((code, { eventPath, plugin, filename }) => {
     code: result ? result.trim() : '',
     meta: {
       handlerName: 'babel/next',
+      pluginName: typeof lastPlugin[0] === 'string' ? lastPlugin[0] : '',
     },
   }
 }: Handler)

--- a/packages/s2s-handler-babel-next/src/index.test.js
+++ b/packages/s2s-handler-babel-next/src/index.test.js
@@ -34,3 +34,11 @@ test('pluginが渡されない場合、エラーを起こすこと', () => {
     handler(code, opts)
   }).toThrow('required plugin')
 })
+
+test('metaデータを返す', () => {
+  const result = handler(code, setup('syntax-flow'))
+  expect(result.meta).toEqual({
+    handlerName: 'babel/next',
+    pluginName: 'syntax-flow',
+  })
+})

--- a/packages/s2s-handler-babel-next/src/index.test.js
+++ b/packages/s2s-handler-babel-next/src/index.test.js
@@ -14,17 +14,17 @@ const setup = (plug = plugin) => {
 
 test('handlerは変換後のコードを返す', () => {
   const result = handler(code, setup())
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('pluginがArrayの場合、変換後のCodeを返す', () => {
   const result = handler(code, setup([plugin, { x: 1 }]))
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('codeが""の場合、""が返ること', () => {
   const result = handler('', setup())
-  expect(result).toBe('')
+  expect(result.code).toBe('')
 })
 
 test('pluginが渡されない場合、エラーを起こすこと', () => {

--- a/packages/s2s-handler-babel/src/index.js
+++ b/packages/s2s-handler-babel/src/index.js
@@ -1,14 +1,11 @@
 // @flow
 import { transform } from 'babel-core'
-import type { Code, HandlerOpts } from 'types'
+import type { Handler } from 'types'
 
 // eslint-disable-next-line
 export type Opts = string | Function | [string | Function, Object]
 
-export default function babelHandler(
-  code: Code,
-  { eventPath, plugin, filename }: HandlerOpts
-): Code {
+export default ((code, { eventPath, plugin, filename }) => {
   if (!plugin || !plugin.plugin) {
     throw new Error('required plugin')
   }
@@ -26,5 +23,10 @@ export default function babelHandler(
     plugins: [lastPlugin],
   })
 
-  return result ? result.trim() : ''
-}
+  return {
+    code: result ? result.trim() : '',
+    meta: {
+      handlerName: 'babel',
+    },
+  }
+}: Handler)

--- a/packages/s2s-handler-babel/src/index.js
+++ b/packages/s2s-handler-babel/src/index.js
@@ -27,6 +27,7 @@ export default ((code, { eventPath, plugin, filename }) => {
     code: result ? result.trim() : '',
     meta: {
       handlerName: 'babel',
+      pluginName: typeof lastPlugin[0] === 'string' ? lastPlugin[0] : '',
     },
   }
 }: Handler)

--- a/packages/s2s-handler-babel/src/index.test.js
+++ b/packages/s2s-handler-babel/src/index.test.js
@@ -14,17 +14,17 @@ const setup = (plug = plugin) => {
 
 test('handlerは変換後のコードを返す', () => {
   const result = handler(code, setup())
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('pluginがArrayの場合、変換後のCodeを返す', () => {
   const result = handler(code, setup([plugin, { x: 1 }]))
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('codeが""の場合、""が返ること', () => {
   const result = handler('', setup())
-  expect(result).toBe('')
+  expect(result.code).toEqual('')
 })
 
 test('pluginが渡されない場合、エラーを起こすこと', () => {

--- a/packages/s2s-handler-babel/src/index.test.js
+++ b/packages/s2s-handler-babel/src/index.test.js
@@ -34,3 +34,11 @@ test('pluginが渡されない場合、エラーを起こすこと', () => {
     handler(code, opts)
   }).toThrow('required plugin')
 })
+
+test('metaデータを返す', () => {
+  const result = handler(code, setup('syntax-flow'))
+  expect(result.meta).toEqual({
+    handlerName: 'babel',
+    pluginName: 'syntax-flow',
+  })
+})

--- a/packages/s2s-handler-typescript/src/index.js
+++ b/packages/s2s-handler-typescript/src/index.js
@@ -1,15 +1,12 @@
 // @flow
 import { transform } from '@babel/core'
 import tsSyntax from '@babel/plugin-syntax-typescript'
-import type { Code, HandlerOpts } from 'types'
+import type { Handler } from 'types'
 
 // eslint-disable-next-line
 export type Opts = string | Function | [string | Function, Object]
 
-export default function babelHandler(
-  code: Code,
-  { eventPath, plugin, filename }: HandlerOpts
-): Code {
+export default ((code, { eventPath, plugin, filename }) => {
   if (!plugin || !plugin.plugin) {
     throw new Error('required plugin')
   }
@@ -27,5 +24,10 @@ export default function babelHandler(
     plugins: [tsSyntax, lastPlugin],
   })
 
-  return result ? result.trim() : ''
-}
+  return {
+    code: result ? result.trim() : '',
+    meta: {
+      handlerName: 'typescript',
+    },
+  }
+}: Handler)

--- a/packages/s2s-handler-typescript/src/index.js
+++ b/packages/s2s-handler-typescript/src/index.js
@@ -28,6 +28,7 @@ export default ((code, { eventPath, plugin, filename }) => {
     code: result ? result.trim() : '',
     meta: {
       handlerName: 'typescript',
+      pluginName: typeof lastPlugin[0] === 'string' ? lastPlugin[0] : '',
     },
   }
 }: Handler)

--- a/packages/s2s-handler-typescript/src/index.test.js
+++ b/packages/s2s-handler-typescript/src/index.test.js
@@ -21,17 +21,17 @@ greeter(user);
 
 test('ts-handlerは変換後のコードを返す', () => {
   const result = handler(code, setup())
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('pluginがArrayの場合', () => {
   const result = handler(code, setup([plugin, { x: 1 }]))
-  expect(result).toMatchSnapshot()
+  expect(result.code).toMatchSnapshot()
 })
 
 test('codeが""の場合、""が返ること', () => {
   const result = handler('', setup())
-  expect(result).toBe('')
+  expect(result.code).toBe('')
 })
 
 test('pluginが渡されない場合、エラーを起こすこと', () => {

--- a/packages/s2s-handler-typescript/src/index.test.js
+++ b/packages/s2s-handler-typescript/src/index.test.js
@@ -41,3 +41,11 @@ test('pluginが渡されない場合、エラーを起こすこと', () => {
     handler(code, opts)
   }).toThrow('required plugin')
 })
+
+test('metaデータを返す', () => {
+  const result = handler(code, setup('@babel/syntax-typescript'))
+  expect(result.meta).toEqual({
+    handlerName: 'typescript',
+    pluginName: '@babel/syntax-typescript',
+  })
+})

--- a/types/index.js
+++ b/types/index.js
@@ -12,7 +12,15 @@ export type HandlerOpts = {
   plugin?: Plugin,
 }
 
-export type Handler = (code: Code, opts: HandlerOpts) => Code
+type Meta = {
+  handlerName: string,
+  pluginName?: string,
+}
+
+export type Handler = (
+  code: Code,
+  opts: HandlerOpts
+) => { code: Code, meta: Meta }
 
 export type Plugin = {|
   test: RegExp | string | string[],


### PR DESCRIPTION
<!--
English/日本語

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!


全て日本語で入力して構いません。むしろ、あなたが日本語に精通していればそちらの方が素早い対応ができます。(ええ、私は日本人です)

プロジェクトに興味を持ってくれてありがとうございます。提出されたバグとPRに感謝します！
このプロジェクトの行動規範(CODE_OF_CONDUCT)を確認し、それに従ってください。（CODE_OF_CONDUCT.mdファイルにあります）

また、あなたがコントリビューションガイドラインを読んでそれに従ってください。（CONTRIBUTING.mdファイルにあります）

もし、これがはじめてのオープンソースへの貢献なら、素晴らしい無料の短いビデオチュートリアルが助けになるはずです。 http://kcd.im/pull-request

レビューを迅速にするために、以下の情報を記入してください。あなたのプルリクエストのマージを期待しています！
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されてしますか？ (機能/バグはここで修正されていますか？) -->
**What**:  Handler型


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:  出力にハンドラ及びプラグインの名前を表示させるため            


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: Handlerの型を変更し、プラグインの名前及び     ハンドラの名前をメタデータとして返すようにした。            


<!-- Have you done all of these things? / これらすべてのことを終えましたか？-->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes / もしあなたの変更に関係がなければそれぞれの行の末尾に"N/A"と追加してください。-->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" / アイテムをチェックするためには、このように"x"と入力します。 "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!--
- [ ] ドキュメント
- [ ] テスト
- [ ] マージされる準備 (あなたの意見では、レビューされたらすぐにマージする準備が整っていますか？)
- [ ] コントリビューションテーブルへ自分を追加 (これはオプションです。コントリビューションガイドを確定してください)
(これは翻訳です。こちらではなく、英語の方にチェックを入れてください)
-->


<!-- feel free to add additional comments. コメントを自由に追加してください-->

Close #103 

破壊的変更で互換性について考えたが、まだバージョンが0.x.xなので、予告なく変更することにする               
